### PR TITLE
feat: Result Module 추가

### DIFF
--- a/FineCode/Result.h
+++ b/FineCode/Result.h
@@ -1,0 +1,44 @@
+
+#include "Employee.h"
+#include <string>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+const int maxEmployeePrintCount = 5;
+
+class Result {    
+public:    
+    Result() { 
+        entryCount = 0; 
+        employees = priority_queue<EmployeeInfo>(); 
+    }
+    ~Result() {}
+
+    void setEntryCountPlus() {
+        entryCount += 1;
+    }
+
+    int getEntryCount() {
+        return entryCount;
+    }
+
+    void employeeAddonResult(EmployeeInfo emp) {
+        employees.push(emp);
+    }
+    
+    vector<string> employeesPrint() {
+        vector<string> ret;
+        for(int i = 0; i < maxEmployeePrintCount; i++) {
+            if(employees.empty()) return ret;
+            ret.push_back(toString(employees.top()));
+            employees.pop();
+        }
+        return ret;
+    }
+    
+private:
+    int entryCount;
+    priority_queue<EmployeeInfo> employees;
+};

--- a/FineCodeUintTest/ResultTest.cpp
+++ b/FineCodeUintTest/ResultTest.cpp
@@ -1,0 +1,16 @@
+#include "gtest/gtest.h"
+#include "../FineCode/IDataBase.h"
+#include "../FineCode/Condition.cpp"
+#include "../FineCode/Result.h"
+
+TEST(RT, ResultTest) {
+    Result *result = new Result();
+
+    EXPECT_EQ(result->getEntryCount(), 0);
+    result->setEntryCountPlus();
+    EXPECT_EQ(result->getEntryCount(), 1);
+    result->setEntryCountPlus();
+    EXPECT_EQ(result->getEntryCount(), 2);
+    result->setEntryCountPlus();
+    EXPECT_EQ(result->getEntryCount(), 3);
+}


### PR DESCRIPTION
Result Module을 따로 추가하였습니다.
그렸던 블록다이어그램과는 조금 다른 형태이지만,
근본적으로 같은 역할을 하는것을 지향합니다.

그리고 priorityQueue를 사용하기 위해 Employee 정보를 비교할수 있는 수식이 있는 class로 상속하였습니다.