### PR TITLE
[feat] seperate cmd class to h and cpp

### DIFF
--- a/FineCode/cmd.h
+++ b/FineCode/cmd.h
@@ -1,72 +1,14 @@
 #pragma once
-#include <memory>
 
-#include "Employee.h"
-#include "Condition.h"
 #include "IDataBase.h"
-#include "Result.h"
-
-// TODO : remove this temporal code
-#ifdef DEBUG_RESULT
-struct Result {
-    string str;
-    bool operator == (Result a) {
-        return this->str == a.str;
-    }
-    void operator = (Result a) {
-        this->str = a.str;
-    }
-};
-#endif
+#include "Employee.h"
 
 struct ICmd {
 public:
-    ICmd(): result() {};
-    virtual Result execute(shared_ptr<IDataBase> database) = 0;
-    virtual void setCondition(shared_ptr<Condition> targetCondition) {}
-protected:
-    Result result;
-};
-
-class CmdAdd : public ICmd {
-public:
-    CmdAdd() : employee(nullptr) {};
-    virtual Result execute(shared_ptr<IDataBase> database) override {
-        return result;
-        // return database.add(employee);
-    }
-private:
-    Employee* employee;
-};
-
-class ICmdTarget : public ICmd {
-public:
-    virtual Result execute(shared_ptr<IDataBase> database) = 0;
-    void setCondition(shared_ptr<Condition> targetCondition) {
-        this->targetCondition = targetCondition;
-    }
-protected:
-    shared_ptr<Condition> targetCondition;
-};
-
-class CmdModify : public ICmdTarget {
-public:
-    virtual Result execute(shared_ptr<IDataBase> database) override {
-        return result;
-        // return database.modify(targetCondition);
-    }
-};
-class CmdSearch : public ICmdTarget {
-public:
-    virtual Result execute(shared_ptr<IDataBase> database) override {
-        return result;
-        // return database.erase(targetCondition);
-    }
-};
-class CmdErase : public ICmdTarget {
-public:
-    virtual Result execute(shared_ptr<IDataBase> database) override {
-        return result;
-        // return database.erase(targetCondition);
-    }
+    static shared_ptr<ICmd> getCmd(string CmdType); // ADD, DEL, SCH, MOD
+    virtual bool execute(const shared_ptr<IDataBase> database) = 0;
+    virtual const vector<string>& getParsedCmd() const = 0;
+    virtual bool setParsedCmd(const vector<string>& parsedCmd)  = 0;
+    virtual void setEmployee(const shared_ptr<Employee> employee) = 0;
+    virtual void setCondition(const shared_ptr<Condition> targetCondition) = 0;
 };

--- a/FineCode/cmd.h
+++ b/FineCode/cmd.h
@@ -3,12 +3,12 @@
 #include "IDataBase.h"
 #include "Employee.h"
 
-struct ICmd {
+class ICmd {
 public:
     static shared_ptr<ICmd> getCmd(string CmdType); // ADD, DEL, SCH, MOD
     virtual bool execute(const shared_ptr<IDataBase> database) = 0;
     virtual const vector<string>& getParsedCmd() const = 0;
-    virtual bool setParsedCmd(const vector<string>& parsedCmd)  = 0;
+    virtual void setParsedCmd(const vector<string>& parsedCmd)  = 0;
     virtual void setEmployee(const shared_ptr<Employee> employee) = 0;
     virtual void setCondition(const shared_ptr<Condition> targetCondition) = 0;
 };

--- a/FineCodeUintTest/testCmd.cpp
+++ b/FineCodeUintTest/testCmd.cpp
@@ -1,6 +1,8 @@
 #include "gtest/gtest.h"
+#include "../FineCode/cmd.cpp"
 #include "../FineCode/cmd.h"
 #include "../FineCode/IDataBase.h"
+#include "../FineCode/Result.h"
 
 namespace {
     class CmdTest : public testing::Test {
@@ -10,28 +12,10 @@ namespace {
         }
         // helper
         bool isSame(Result a, Result b) {
-            return a == b;
-        }
-
-        void factory(string str) {
-            if (str == "CmdAdd") {
-                icmd = make_shared <CmdAdd>();
-            }
-            else if (str == "CmdModify") {
-                icmd = make_shared<CmdModify>();
-            }
-            else if (str == "CmdSearch") {
-                icmd = make_shared<CmdSearch>();
-            }
-            else if (str == "CmdErase") {
-                icmd = make_shared<CmdErase>();
-            }
-            else {
-                cout << "invalid Cmd\n";
-            }
+            //return a == b;
+            return false;
         }
         // common data
-        shared_ptr<ICmd> icmd;
         shared_ptr<IDataBase> db;
         Result result;
     };
@@ -39,66 +23,74 @@ namespace {
 
     // ADD
     TEST_F(CmdTest, CmdAddSuccess) {
-        factory("CmdAdd");
-        Result expected{ "NOK" };
-        result = icmd->execute(db);
+        shared_ptr<ICmd> add = ICmd::getCmd("ADD");
+        Employee employee = { 2015123099, { "VXIHXOTH", "JHOP" }, CL::CL3, { 3112,2609 }, { 1977,12,11 }, Grade::ADV };
 
-        EXPECT_TRUE(isSame(expected, result));
+        EXPECT_TRUE(add->execute(db));
     }
 
     TEST_F(CmdTest, CmdAddFail) {
-        factory("CmdAdd");
-        Result expected{"OK"};
-        result = icmd->execute(db);
-
-        EXPECT_TRUE(!isSame(expected, result));
+        shared_ptr<ICmd> icmd = ICmd::getCmd("ADD");
+        Employee employee = { 99, { "VXIHXOTH", "JHOP" }, CL::CL3, { 3112,2609 }, { 1977,12,11 }, Grade::ADV };
+        icmd->setEmployee(make_shared<Employee>(employee));
+        EXPECT_TRUE(!icmd->execute(db));
     }
 
     // Modify
     TEST_F(CmdTest, CmdModifySuccess) {
-        factory("CmdModify");
-        Result expected{ "NOK" };
-        result = icmd->execute(db);
-
-        EXPECT_TRUE(isSame(expected, result));
+        shared_ptr<ICmd> add = ICmd::getCmd("ADD");
+        Employee employee = { 2015123099, { "VXIHXOTH", "JHOP" }, CL::CL3, { 3112,2609 }, { 1977,12,11 }, Grade::ADV };
+        EXPECT_TRUE(add->execute(db));
+        shared_ptr<ICmd> mod = ICmd::getCmd("MOD");
+        Employee employee1 = { 2015123099, { "VXIHXOTH", "JHOP" }, CL::CL2, { 3112,2609 }, { 1977,12,11 }, Grade::ADV };
+        // TODO : Get right Condition instance
+        shared_ptr<Condition> cond;
+        mod->setCondition(cond);
+        EXPECT_TRUE(mod->execute(db));
     }
     TEST_F(CmdTest, CmdModifyFail) {
-        factory("CmdModify");
-        Result expected{ "OK" };
-        result = icmd->execute(db);
-
-        EXPECT_TRUE(!isSame(expected, result));
+        shared_ptr<ICmd> mod = ICmd::getCmd("MOD");
+        Employee employee = { 2015123099, { "VXIHXOTH", "JHOP" }, CL::CL3, { 3112,2609 }, { 1977,12,11 }, Grade::ADV };
+        shared_ptr<Condition> cond;
+        mod->setCondition(cond);
+        EXPECT_TRUE(!mod->execute(db));
     }
 
     // Search
     TEST_F(CmdTest, CmdSearchSuccess) {
-        factory("CmdSearch");
-        Result expected{ "NOK" };
-        result = icmd->execute(db);
-
-        EXPECT_TRUE(isSame(expected, result));
+        shared_ptr<ICmd> add = ICmd::getCmd("ADD");
+        Employee employee = { 2015123099, { "VXIHXOTH", "JHOP" }, CL::CL3, { 3112,2609 }, { 1977,12,11 }, Grade::ADV };
+        EXPECT_TRUE(add->execute(db));
+        shared_ptr<ICmd> sch = ICmd::getCmd("SCH");
+        Employee employee1 = { 2015123099, { "VXIHXOTH", "JHOP" }, CL::CL3, { 3112,2609 }, { 1977,12,11 }, Grade::ADV };
+        shared_ptr<Condition> cond;
+        sch->setCondition(cond);
+        EXPECT_TRUE(sch->execute(db));
     }
     TEST_F(CmdTest, CmdSearchFail) {
-        factory("CmdSearch");
-        Result expected{ "OK" };
-        result = icmd->execute(db);
-
-        EXPECT_TRUE(!isSame(expected, result));
+        shared_ptr<ICmd> sch = ICmd::getCmd("SCH");
+        Employee employee = { 2015123099, { "VXIHXOTH", "JHOP" }, CL::CL3, { 3112,2609 }, { 1977,12,11 }, Grade::ADV };
+        shared_ptr<Condition> cond;
+        sch->setCondition(cond);
+        EXPECT_TRUE(!sch->execute(db));
     }
 
     // Erase
     TEST_F(CmdTest, CmdEraseSuccess) {
-        factory("CmdErase");
-        Result expected{ "NOK" };
-        result = icmd->execute(db);
-
-        EXPECT_TRUE(isSame(expected, result));
+        shared_ptr<ICmd> add = ICmd::getCmd("ADD");
+        Employee employee = { 2015123099, { "VXIHXOTH", "JHOP" }, CL::CL3, { 3112,2609 }, { 1977,12,11 }, Grade::ADV };
+        EXPECT_TRUE(add->execute(db));
+        shared_ptr<ICmd> del = ICmd::getCmd("DEL");
+        Employee employee1 = { 2015123099, { "VXIHXOTH", "JHOP" }, CL::CL3, { 3112,2609 }, { 1977,12,11 }, Grade::ADV };
+        shared_ptr<Condition> cond;
+        del->setCondition(cond);
+        EXPECT_TRUE(del->execute(db));
     }
     TEST_F(CmdTest, CmdEraseFail) {
-        factory("CmdErase");
-        Result expected{ "OK" };
-        result = icmd->execute(db);
-
-        EXPECT_TRUE(!isSame(expected, result));
+        shared_ptr<ICmd> del = ICmd::getCmd("DEL");
+        Employee employee = { 2015123099, { "VXIHXOTH", "JHOP" }, CL::CL3, { 3112,2609 }, { 1977,12,11 }, Grade::ADV };
+        shared_ptr<Condition> cond;
+        del->setCondition(cond);
+        EXPECT_TRUE(!del->execute(db));
     }
 }


### PR DESCRIPTION
[feat] seperate cmd class
 
   1. cmd class를 header 와 cpp로 분리
   2. cmd class에서 factory method를 이용하여 instance 생성 가능하게 함.( testcase 참조)
   3. test case 정비
   4. TODO : 적절한 condition instance를 가져와야 한다.